### PR TITLE
Returns the value in the same order it is set

### DIFF
--- a/adafruit_ws2801.py
+++ b/adafruit_ws2801.py
@@ -144,14 +144,14 @@ class WS2801:
             out = []
             for in_i in range(*index.indices(self._n)):
                 out.append(
-                    tuple(self._buf[in_i * 3 + (2 - i)] for i in range(3)))
+                    tuple(self._buf[in_i * 3 + i] for i in range(3)))
             return out
         if index < 0:
             index += len(self)
         if index >= self._n or index < 0:
             raise IndexError
         offset = index * 3
-        return tuple(self._buf[offset + (2 - i)] for i in range(3))
+        return tuple(self._buf[offset + i] for i in range(3))
 
     def __len__(self):
         return self._n


### PR DESCRIPTION
Fixes #9. Tested with:
```
import board
import adafruit_ws2801

odata = board.D5
oclock = board.D6
numleds = 25
bright = 1.0
leds = adafruit_ws2801.WS2801(oclock, odata, numleds, brightness=bright, auto_write=True)
```

```
>>> leds[0] = (255, 0, 0)
>>> leds[0]
(255, 0, 0)
>>> leds[0:3] = ((255, 0, 0), (0, 255, 0), (0, 0, 255))
>>> leds[0:3]
[(255, 0, 0), (0, 255, 0), (0, 0, 255)]
```