### PR TITLE
Update adafruit_ws2801.py

### DIFF
--- a/adafruit_ws2801.py
+++ b/adafruit_ws2801.py
@@ -195,7 +195,7 @@ class WS2801:
         buf = self._buf
         if self.brightness < 1.0:
             buf = bytearray(len(self._buf))
-            for i in range(self._n):
+            for i in range(len(self._buf)):
                 buf[i] = int(self._buf[i] * self._brightness)
 
         if self._spi:


### PR DESCRIPTION
With the current implementation only first third of LEDs were updated (because len(_buf) = 3*n), now all of them are.